### PR TITLE
POM implementation EntityVisibilityEventsTest

### DIFF
--- a/src/test/java/model/entity/common/MainPage.java
+++ b/src/test/java/model/entity/common/MainPage.java
@@ -71,6 +71,9 @@ public class MainPage extends BaseIndexPage {
     @FindBy(xpath = "//p[contains (text(), 'Child records loop')]/parent::a")
     private WebElement childRecordsLoop;
 
+    @FindBy(xpath = "//p[contains (text(), 'Visibility')]/parent::a")
+    private WebElement menuVisibilityEvents;
+
     public MainPage(WebDriver driver) {
         super(driver);
     }
@@ -173,5 +176,10 @@ public class MainPage extends BaseIndexPage {
     public ChildRecordsLoopPage clickMenuChildRecordsLoop() {
         clickMainMenu(childRecordsLoop);
         return new ChildRecordsLoopPage(getDriver());
+    }
+
+    public VisibilityEventsPage clickMenuVisibilityEvents() {
+        clickMainMenu(menuVisibilityEvents);
+        return new VisibilityEventsPage(getDriver());
     }
 }

--- a/src/test/java/model/entity/edit/VisibilityEventsEditPage.java
+++ b/src/test/java/model/entity/edit/VisibilityEventsEditPage.java
@@ -1,0 +1,47 @@
+package model.entity.edit;
+
+import model.base.EntityBaseEditPage;
+import model.entity.table.VisibilityEventsPage;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import runner.ProjectUtils;
+
+public class VisibilityEventsEditPage extends EntityBaseEditPage<VisibilityEventsPage> {
+
+    @FindBy(xpath = "//span[@class='toggle']")
+    private WebElement toggle;
+
+    @FindBy(id = "test_field")
+    private WebElement inputTestField;
+
+    public VisibilityEventsEditPage(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    protected VisibilityEventsPage createPage() {
+        return new VisibilityEventsPage(getDriver());
+    }
+
+    public VisibilityEventsEditPage clickToggle() {
+        toggle.click();
+        return this;
+    }
+
+    public boolean isTestFieldVisible() {
+        try {
+            getWait().until(ExpectedConditions.visibilityOf(inputTestField));
+            return true;
+        } catch (TimeoutException ignored) {
+            return false;
+        }
+    }
+
+    public VisibilityEventsEditPage fillInputTestField(String text) {
+        ProjectUtils.fill(getWait(), getWait().until(ExpectedConditions.visibilityOf(inputTestField)), text);
+        return this;
+    }
+}

--- a/src/test/java/model/entity/table/VisibilityEventsPage.java
+++ b/src/test/java/model/entity/table/VisibilityEventsPage.java
@@ -1,0 +1,43 @@
+package model.entity.table;
+
+import model.base.EntityBaseTablePage;
+import model.entity.edit.VisibilityEventsEditPage;
+import model.entity.view.VisibilityEventsViewPage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class VisibilityEventsPage extends EntityBaseTablePage<VisibilityEventsPage, VisibilityEventsEditPage, VisibilityEventsViewPage> {
+
+    public VisibilityEventsPage(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    protected VisibilityEventsEditPage createEditPage() {
+        return new VisibilityEventsEditPage(getDriver());
+    }
+
+    @Override
+    protected VisibilityEventsViewPage createViewPage() {
+        return new VisibilityEventsViewPage(getDriver());
+    }
+
+    public String getRecordTriggerClass(int rowNumber) {
+        try {
+            return getRows().get(rowNumber).findElement(By.xpath("//td[2]/i")).getAttribute("class");
+        } catch (NoSuchElementException ignored) {
+            return "";
+        }
+    }
+
+    @Override
+    public List<String> getRow(int rowNumber) {
+        return getRows().get(rowNumber).findElements(By.tagName("td")).stream()
+                .map(WebElement::getText).collect(Collectors.toList()).subList(0, 3);
+    }
+}

--- a/src/test/java/model/entity/view/VisibilityEventsViewPage.java
+++ b/src/test/java/model/entity/view/VisibilityEventsViewPage.java
@@ -1,0 +1,11 @@
+package model.entity.view;
+
+import model.base.EntityBaseViewPage;
+import org.openqa.selenium.WebDriver;
+
+public class VisibilityEventsViewPage extends EntityBaseViewPage {
+
+    public VisibilityEventsViewPage(WebDriver driver) {
+        super(driver);
+    }
+}


### PR DESCRIPTION
[Trello : POM EntityVisibilityEventsTest](https://trello.com/c/9kdOQLeA/601-pom-entityvisibilityeventstest)

Note: editEventTest can be improved to perform better timewise, at this moment there's 10 sec delay caused by implicit wait application